### PR TITLE
(chore) Support Chef 12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 before_install:
   - bundle install --path .bundle
 rvm:
-  - 1.9.3
   - 2.1.0
   - 2.1.2
 branches:

--- a/blender-chef.gemspec
+++ b/blender-chef.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'pd-blender'
-  spec.add_dependency 'chef'
+  spec.add_dependency 'chef', '>= 12.0.0'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'
@@ -25,4 +25,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop'
   spec.add_development_dependency 'simplecov'
   spec.add_development_dependency 'yard'
+  spec.add_development_dependency 'fauxhai'
 end

--- a/lib/blender/discoveries/chef.rb
+++ b/lib/blender/discoveries/chef.rb
@@ -41,28 +41,8 @@ module Blender
         end
         attr = options[:attribute] || 'fqdn'
         q = ::Chef::Search::Query.new
-        res = q.search(:node, search_term)
-        res.first.collect{|n| node_attribute(n, attr)}
-      end
-
-      private
-      def node_attribute(data, nested_value_spec)
-        nested_value_spec.split(".").each do |attr|
-          if data.nil?
-            nil # don't get no method error on nil
-          elsif data.respond_to?(attr.to_sym)
-            data = data.send(attr.to_sym)
-          elsif data.respond_to?(:[])
-            data = data[attr]
-          else
-            data = begin
-              data.send(attr.to_sym)
-            rescue NoMethodError
-              nil
-            end
-          end
-        end
-        ( !data.kind_of?(Array) && data.respond_to?(:to_hash) ) ? data.to_hash : data
+        res = q.search(:node, search_term, filter_result: {attribute: attr.split('.')})
+        res.first.collect{|node_data| node_data['data']['attribute']}
       end
     end
   end

--- a/spec/blender/discoveries/chef_spec.rb
+++ b/spec/blender/discoveries/chef_spec.rb
@@ -4,36 +4,15 @@ require 'blender/discoveries/chef'
 describe Blender::Discovery::Chef do
   let(:discovery){described_class.new}
   it '#search' do
-    query = double(Chef::Search::Query)
-    expect(query).to receive(:search).with(
-      :node,
-      '*:*',
-      filter_result: {
-        attribute: ['fqdn']
-      }
-    ).and_return([['data'=> { 'attribute'=> 'a'}]])
-    expect(Chef::Search::Query).to receive(:new).and_return(query)
-    expect(discovery.search).to eq(['a'])
+    expect(discovery.search.size).to be(10)
   end
   it '#search with options' do
     disco = described_class.new(
-      config_file: 'foo.rb',
-      node_name: 'bar',
-      client_key: 'baz.rb',
-      attribute: 'x.y.z'
+      chef_server_url: 'http://localhost:8889',
+      node_name: 'admin',
+      client_key: SpecHelper.client_key.path,
+      attribute: 'name'
     )
-    query = double(Chef::Search::Query)
-    expect(Chef::Config).to receive(:from_file).with('foo.rb')
-    expect(query).to receive(:search).with(
-      :node,
-      'name:x',
-      filter_result: {
-        attribute: %w{x y z}
-      }
-    ).and_return([[{'data'=>{'attribute'=> 123}}]])
-    expect(Chef::Search::Query).to receive(:new).and_return(query)
-    expect(disco.search('name:x')).to eq([123])
-    expect(Chef::Config[:client_key]).to eq('baz.rb')
-    expect(Chef::Config[:node_name]).to eq('bar')
+    expect(disco.search('name:node-1')).to eq(['node-1'])
   end
 end

--- a/spec/blender/discoveries/chef_spec.rb
+++ b/spec/blender/discoveries/chef_spec.rb
@@ -5,9 +5,13 @@ describe Blender::Discovery::Chef do
   let(:discovery){described_class.new}
   it '#search' do
     query = double(Chef::Search::Query)
-    node = Chef::Node.new
-    node.set['fqdn'] = 'a'
-    expect(query).to receive(:search).with(:node, '*:*').and_return([[node]])
+    expect(query).to receive(:search).with(
+      :node,
+      '*:*',
+      filter_result: {
+        attribute: ['fqdn']
+      }
+    ).and_return([['data'=> { 'attribute'=> 'a'}]])
     expect(Chef::Search::Query).to receive(:new).and_return(query)
     expect(discovery.search).to eq(['a'])
   end
@@ -19,10 +23,14 @@ describe Blender::Discovery::Chef do
       attribute: 'x.y.z'
     )
     query = double(Chef::Search::Query)
-    node = Chef::Node.new
-    node.set['x'] = { 'y' => { 'z' => 123 } }
     expect(Chef::Config).to receive(:from_file).with('foo.rb')
-    expect(query).to receive(:search).with(:node, 'name:x').and_return([[node]])
+    expect(query).to receive(:search).with(
+      :node,
+      'name:x',
+      filter_result: {
+        attribute: %w{x y z}
+      }
+    ).and_return([[{'data'=>{'attribute'=> 123}}]])
     expect(Chef::Search::Query).to receive(:new).and_return(query)
     expect(disco.search('name:x')).to eq([123])
     expect(Chef::Config[:client_key]).to eq('baz.rb')

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,8 +1,49 @@
 require 'blender'
+require 'chef_zero/server'
+require 'fileutils'
+require 'chef/node'
+require 'tempfile'
+require 'fauxhai'
+
+module SpecHelper
+  extend self
+  def server
+    $server ||= ChefZero::Server.new
+  end
+  def client_key
+    $client_key ||= Tempfile.new('client.pem')
+  end
+  def setup
+    server.start_background
+    Chef::Config[:chef_server_url] = 'http://127.0.0.1:8889'
+    Chef::Config[:node_name] = 'admin'
+    Chef::Config[:client_key] = client_key.path
+    client_key.write(server.gen_key_pair.first)
+    client_key.close
+    10.times do |n|
+      node = Chef::Node.new
+      node.name('node-'+ (n+1).to_s)
+      node.consume_attributes(
+        Fauxhai.mock(platform: 'ubuntu', version: '14.04').data
+      )
+      node.save
+    end
+  end
+  def cleanse
+    client_key.unlink
+    server.stop
+  end
+end
 
 RSpec.configure do |config|
   config.mock_with :rspec do |mocks|
     mocks.verify_doubled_constant_names = true
+  end
+  config.before(:suite) do
+    SpecHelper.setup
+  end
+  config.after(:suite) do
+    SpecHelper.cleanse
   end
   config.backtrace_exclusion_patterns = []
 end


### PR DESCRIPTION
Enforces partial search, i.e. blender-chef will be chef 12+ compatible only.
