### PR TITLE
(chore)add config for ssh multi driver

### DIFF
--- a/lib/chef/knife/blender.rb
+++ b/lib/chef/knife/blender.rb
@@ -147,6 +147,7 @@ class Chef
         Blender.blend('blender-chef', scheduler_options) do |scheduler|
           scheduler.strategy(config[:strategy])
           scheduler.config(:ssh, ssh_config)
+          scheduler.config(:ssh_multi, ssh_config)
           scheduler.config(:scp, ssh_config)
           scheduler.members(members)
           @name_args.each do |file|


### PR DESCRIPTION
upstream blender now automatically use ssh_multi driver if ssh_task specifies concurrency higher than 1
