### PR TITLE
Fix chef-zero to 14.0.0 or below

### DIFF
--- a/blender-chef.gemspec
+++ b/blender-chef.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'pd-blender', '>= 0.5'
+  spec.add_dependency 'chef-zero', '<= 14.0.0'
   spec.add_dependency 'chef', '>= 12.1.1'
 
   spec.add_development_dependency 'bundler'


### PR DESCRIPTION
`blender-chef` depends on `chef` which depends on `chef-zero`. This adds
the `chef-zero` dependency directly and fixes it be `14.0.0` or below as
this is the last version of `chef-zero` that allows for `chef` less than
`14.0` and `ruby-2.3.1`. Newer versions of `chef-zero` require
`ruby-2.4.0`.